### PR TITLE
fixed material links

### DIFF
--- a/web/templates/organize/organize.html
+++ b/web/templates/organize/organize.html
@@ -39,8 +39,7 @@
           <li>sopivan tilan.</li>
         </ul>
 
-        <p><a href="https://github.com/koodikoulu/koodikoulu" target="_blank">Ohjeet ja materiaalit Koodikoulun GitHubista</a></p>
-        <p><a href="https://vimeo.com/86706312" target="_blank">Tässä vielä video Koodikoulun ensiaskeleen järjestämisestä</a></p>
+        <p><a href="http://koodikoulu.github.io/koodikoulu/" target="_blank">Ohjeet ja materiaalit Koodikoulun järjestämiseen</a></p>
       </div>
     </div>
     <div class="row">
@@ -52,8 +51,7 @@
 
         <p>Koodikoulun iltis on koululaisten iltapäiväkerho ohjelmoinnin perusteiden oppimiseen. Voit toimia itse iltiksen vetäjänä! Se järjestetään paikallisen koulun tiloissa ja tuella. Iltis tarjoaa valmiit opetusmateriaalit ja perehdytyksen.</p>
 
-        <p><a href="http://koodikerho.fi/ilmoittaudu/" target="_blank">Ilmoittaudu ohjaajaksi Koodikerhon sivulla</a></p>
-        <p><a href="http://koodikerho.fi/materiaalit/" target="_blank">Tutustu materiaaleihin</a></p>
+        <p><a href="http://koodikerho.fi/materiaalit/" target="_blank">Tutustu materiaaleihin ja ilmoittaudu ohjaajaksi</a></p>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Fixed material links to point to github.io-page in Koodikoulu case and only one link to Koodikerho page also.
